### PR TITLE
[Feat] #18 - 설정 뷰 UI 구현

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct NotiSettingView: View {
+    
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    
+    @State private var appNotiToggle = false
+    @State private var nightAppNotiToggle = false
+    
+    // backButton 커스텀
+    var backButton: some View {
+        Button{
+            self.presentationMode.wrappedValue.dismiss()
+        } label: {
+            HStack {
+                Image(systemName: "chevron.left")
+                    .foregroundStyle(.black)
+                    .aspectRatio(contentMode: .fill)
+                    .fontWeight(.medium)
+            }
+        }
+    }
+    
+    var body: some View {
+                    
+        VStack(alignment: .leading, spacing: 10) {
+            Text("푸시 알림")
+                .font(.system(size: 18, weight: .medium))
+        
+            Toggle("앱 알림", isOn: $appNotiToggle)
+                .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
+            
+            Toggle(isOn: $nightAppNotiToggle) {
+                Text("야간 알림")
+                    .font(.system(size: 16))
+                + Text("(21시~08시)")
+                    .font(.system(size: 16))
+                    .foregroundColor(.gray)
+            }
+                .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
+        }
+        .padding(.leading, 40)
+        .padding(.trailing, 40)
+        .padding(.bottom, 610)
+        .navigationBarBackButtonHidden(true)
+        
+        // 상단 toolBar
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                backButton
+            }
+            
+            ToolbarItem(placement: .principal) {
+                Text("알림 설정")
+                    .font(.system(size: 18, weight: .semibold))
+            }
+        }
+
+    }
+}
+
+#Preview {
+    NotiSettingView()
+}

--- a/MenuTaro/MenuTaro/Sources/Views/SettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/SettingView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct SettingView: View {
+    
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    
+    // backButton 커스텀
+    var backButton: some View {
+        Button{
+            self.presentationMode.wrappedValue.dismiss()
+        } label: {
+            HStack {
+                Image(systemName: "chevron.left")
+                    .foregroundStyle(.black)
+                    .aspectRatio(contentMode: .fill)
+                    .fontWeight(.medium)
+            }
+        }
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack (alignment: .leading, spacing: 6) {
+                Text("공지사항")
+                    .padding(10)
+                    .font(.system(size: 20, weight: .bold))
+                NavigationLink(destination: NotiSettingView()) {
+                    Text("알림 설정")
+                        .padding(10)
+                }
+                Text("버그 신고")
+                    .padding(10)
+                Text("고객센터/문의하기")
+                    .padding(10)
+                Text("약관 및 개인정보 처리방침")
+                    .padding(10)
+                Text("App version: Beta")
+                    .padding(10)
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundColor(.gray)
+            }
+            .padding(.leading, -140)
+            .padding(.bottom, 410)
+            .foregroundColor(.black)
+            .font(.system(size: 18, weight: .medium))
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                backButton
+            }
+            
+            ToolbarItem(placement: .principal) {
+                Text("설정")
+                    .font(.system(size: 18, weight: .semibold))
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingView()
+}


### PR DESCRIPTION
**무엇을 했는지?**

설정 뷰 UI 구현

<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/ccfddb13-1fe6-422f-81f6-6cdddf9c5b59" />
<img width="200" height="425" alt="image" src="https://github.com/user-attachments/assets/b008e855-bd4c-4f42-bcd1-350d230a808a" />

- 설정 뷰의 상단 BackButton과 Title 관련은 추후 추가 예정 (현재 설정으로 가는 NavigationLink가 없기 때문에)

**관련 이슈**
#18 