### PR TITLE
[Chore] #22 - 상단 공통 Toolbar 컴포넌트화

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Components/CustomToolbar.swift
+++ b/MenuTaro/MenuTaro/Sources/Components/CustomToolbar.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+// NavigationStack으로 이동한 View에 사용
+struct CustomToolbar: ViewModifier {
+    var title: String
+    var onBack: (() -> Void)?
+    var showBackButton: Bool = true
+    
+    func body(content: Content) -> some View {
+        content
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                if showBackButton {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button {
+                            onBack?()
+                        } label: {
+                            HStack {
+                                Image(systemName: "chevron.left")
+                                    .foregroundColor(.white)
+                                    .aspectRatio(contentMode: .fill)
+                                    .fontWeight(.medium)
+                            }
+                        }
+                    }
+                }
+                ToolbarItem(placement: .principal) {
+                    Text(title)
+                        .font(.system(size: 18, weight: .semibold))
+                }
+            }
+    }
+}
+
+extension View {
+    func customToolbar(title: String, showBackButton: Bool = true, onBack: (() -> Void)? = nil) -> some View {
+        self.modifier(CustomToolbar(title: title, onBack: onBack, showBackButton: showBackButton))
+    }
+}

--- a/MenuTaro/MenuTaro/Sources/Components/CustomTopbar.swift
+++ b/MenuTaro/MenuTaro/Sources/Components/CustomTopbar.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+// NavigationStack에 쌓여있지 않은 화면에서 사용 (뒤로가기 버튼 필요 X)
+struct customTopbar: View {
+    var title: String
+    
+    var body: some View {
+         Text(title)
+            .font(.system(size: 18, weight: .semibold))
+            .padding(.bottom, 10)
+    }
+}

--- a/MenuTaro/MenuTaro/Sources/Views/BookmarkCategoryView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/BookmarkCategoryView.swift
@@ -17,6 +17,7 @@ struct BookmarkCategoryListView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 12) {
+                customTopbar(title: "북마크")
                 // 모든 메뉴 (전용 카드)
                 Button{
                     router.push(.bookmarkList( category: nil))

--- a/MenuTaro/MenuTaro/Sources/Views/MypageView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/MypageView.swift
@@ -19,6 +19,7 @@ struct MypageView: View {
     var body: some View {
             ScrollView {
                 VStack(spacing: 20) {
+                    customTopbar(title: "마이페이지")
                     HStack {
                         ZStack {
                             LinearGradient(

--- a/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
@@ -13,6 +13,7 @@ struct NavigationRootView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var bgStyle: AppBackgroundView.Style = .black
     @State private var didSeedInitialData = false
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
     var body: some View {
         ZStack {
@@ -67,22 +68,22 @@ struct NavigationRootView: View {
         switch step {
         case .selection:
             SnackTaro()
-                .navigationTitle("포춘 쿠키")
-                .navigationBarTitleDisplayMode(.inline)
+                .customToolbar(title: "포춘 쿠키") {
+                    presentationMode.wrappedValue.dismiss()
+                }
         case .opening:
             SnackTaro2()
-                .navigationTitle("포춘 쿠키")
-                .navigationBarTitleDisplayMode(.inline)
+                .customToolbar(title: "포춘 쿠키") {
+                    presentationMode.wrappedValue.dismiss()
+                }
         case .reveal:
             SnackTaro3()
-                .navigationBarBackButtonHidden()
-                .navigationTitle("포춘 쿠키")
-                .navigationBarTitleDisplayMode(.inline)
+                .customToolbar(title: "포춘 쿠키", showBackButton: false) {
+                }
         case .result:
             SnackTaro4()
-                .navigationBarBackButtonHidden()
-                .navigationTitle("포춘 쿠키")
-                .navigationBarTitleDisplayMode(.inline)
+                .customToolbar(title: "포춘 쿠키", showBackButton: false) {
+                }
         }
     }
 }

--- a/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
@@ -7,20 +7,6 @@ struct NotiSettingView: View {
     @State private var appNotiToggle = false
     @State private var nightAppNotiToggle = false
     
-    // backButton 커스텀
-    var backButton: some View {
-        Button{
-            self.presentationMode.wrappedValue.dismiss()
-        } label: {
-            HStack {
-                Image(systemName: "chevron.left")
-                    .foregroundStyle(.black)
-                    .aspectRatio(contentMode: .fill)
-                    .fontWeight(.medium)
-            }
-        }
-    }
-    
     var body: some View {
                     
         VStack(alignment: .leading, spacing: 10) {
@@ -42,20 +28,9 @@ struct NotiSettingView: View {
         .padding(.leading, 40)
         .padding(.trailing, 40)
         .padding(.bottom, 610)
-        .navigationBarBackButtonHidden(true)
-        
-        // 상단 toolBar
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                backButton
-            }
-            
-            ToolbarItem(placement: .principal) {
-                Text("알림 설정")
-                    .font(.system(size: 18, weight: .semibold))
-            }
+        .customToolbar(title: "알림 설정") {
+            presentationMode.wrappedValue.dismiss()
         }
-
     }
 }
 


### PR DESCRIPTION
# 무엇을 했는지?

상단에 공통으로 작성되는 Toolbar를 컴포넌트화 했습니다.

1. **`customToolbar`**: NavigationStack으로 이동해 backButton까지 함께 필요한 경우
```swift
// 현재 화면의 표시 상태(presentation 상태)를 제어하기 위한 환경 값
@Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>

... 기존 코드 ...

customTopbar(title: "타이틀 이름") {
    presentationMode.wrappedValue.dismiss()
}
```
+) 필요에 따라 `showBackButton = false`로 설정해 안보이게 할 수 있음
<br>

2. **`customTopbar`**: 메인 화면에 필요한 경우 (backButton 없음)
```swift
.customTopbar(title: "타이틀 이름")
```
<br>

**참고**
- 현재 SettingView로 넘어가는 navigationStack이 구현이 안되어 있기 때문에 SettingView에는 추후 컴포넌트 코드로 수정 예정
- 기본이 검정 배경이기 때문에 `backButton`의 컬러는 `.white`로 고정함 (Preview에서 보면 배경이 흰색이라 backButton 안보임)
<br>

**관련 이슈**
#22 