### PR TITLE
온보딩 연결, 사용자 정보 저장, merge

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Components/ProfileCharacterGrid.swift
+++ b/MenuTaro/MenuTaro/Sources/Components/ProfileCharacterGrid.swift
@@ -1,0 +1,61 @@
+//
+//  ProfileCharacterGrid.swift
+//  MenuTaro
+//
+//  Created by mac mini on 11/5/25.
+//
+
+
+//
+//  ProfileCharacterGrid.swift
+//  MenuTaro
+//
+//  Created by mac mini on 11/5/25.
+//
+
+
+import SwiftUI
+
+/// 공용 캐릭터 그리드 뷰 (LazyVGrid 래핑)
+struct ProfileCharacterGrid: View {
+    @ObservedObject var viewModel: OnboardingProfileCharacterViewModel
+
+    // 레이아웃 파라미터
+    var columnsCount: Int = 2
+    var horizontalPaddingRatio: CGFloat = 0.10   // 화면 너비의 10%
+    var gridSpacingRatio: CGFloat = 0.06         // 화면 너비의 6%
+
+    var body: some View {
+        GeometryReader { proxy in
+            let horizontalPadding = proxy.size.width * horizontalPaddingRatio
+            let gridSpacing = proxy.size.width * gridSpacingRatio
+            let columns: [GridItem] = Array(
+                repeating: GridItem(.flexible(), spacing: gridSpacing),
+                count: columnsCount
+            )
+            let avatarDiameter = (proxy.size.width - (horizontalPadding * 2) - gridSpacing * CGFloat(columnsCount - 1))
+            / CGFloat(columnsCount)
+
+            LazyVGrid(columns: columns, alignment: .center, spacing: gridSpacing) {
+                ForEach(viewModel.characters, id: \.self) { character in
+                    let backgroundStyle = viewModel.backgroundStyle(for: character)
+
+                    Button {
+                        viewModel.toggleSelection(for: character)
+                    } label: {
+                        ProfileCharacterAvatar(
+                            imageName: character,
+                            diameter: avatarDiameter,
+                            backgroundStyle: backgroundStyle
+                        )
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, horizontalPadding)
+        }
+        // 부모 뷰가 높이를 결정하도록 확장
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}

--- a/MenuTaro/MenuTaro/Sources/MenuTaroApp.swift
+++ b/MenuTaro/MenuTaro/Sources/MenuTaroApp.swift
@@ -3,7 +3,6 @@ import SwiftData
 
 @main
 struct MenuTaroAppApp: App {
-    @AppStorage("hasOnboarded") var hasOnboarded = false // 온보딩 표시 여부, 온보딩을 안봤으면 앱 초기 실행이므로 프로필 설정도 해줘야함
     @StateObject private var router = Router()
     var body: some Scene {
         WindowGroup {

--- a/MenuTaro/MenuTaro/Sources/Routing/AppRoute.swift
+++ b/MenuTaro/MenuTaro/Sources/Routing/AppRoute.swift
@@ -16,6 +16,8 @@ public enum AppRoute: Hashable {
     case snackFortune(step: SnackFortuneStep)
     case menuTaro
     case MenuTaroSelected(foodId: UUID)
+    case onboarding(step: OnboardingStep)
+    case mypageEdit
 }
 
 public extension AppRoute {
@@ -42,6 +44,10 @@ public extension AppRoute {
             return Identifier(key: "menuTaro")
         case let .MenuTaroSelected(foodId):
             return Identifier(key: "MenuTaroSelected", value: foodId.uuidString)
+        case let .onboarding(step):
+            return Identifier(key: "onboarding", value: step.rawValue)
+        case .mypageEdit:
+            return Identifier(key: "mypageEdit")
         }
     }
     
@@ -72,6 +78,15 @@ public extension AppRoute {
                 return nil
             }
             self = .MenuTaroSelected(foodId: foodId)
+        case "onboarding":
+            guard let value = identifier.value,
+                  let step = OnboardingStep(rawValue: value) else {
+                return nil
+            }
+            self = .onboarding(step: step)
+        case "mypageEdit":
+            self = .mypageEdit
+            
         default :
             return nil
         }
@@ -86,3 +101,8 @@ public enum SnackFortuneStep: String, Hashable, Codable,CaseIterable {
     case result
 }
 
+public enum OnboardingStep: String, Hashable, Codable, CaseIterable {
+    case name
+    case profile
+    case terms
+}

--- a/MenuTaro/MenuTaro/Sources/ViewModels/OnboardingViewModel/OnboardingFlowViewModel.swift
+++ b/MenuTaro/MenuTaro/Sources/ViewModels/OnboardingViewModel/OnboardingFlowViewModel.swift
@@ -1,0 +1,100 @@
+//
+//  OnboardingFlowViewModel.swift
+//  MenuTaro
+//
+//  Created by mac mini on 11/5/25.
+//
+
+
+//
+//  OnboardingFlowViewModel.swift
+//  MenuTaro
+//
+//  Created by mac mini on 11/5/25.
+//
+
+import SwiftUI
+import SwiftData
+import Combine
+
+@MainActor
+final class OnboardingFlowViewModel: ObservableObject {
+    @Published var nickname: String = ""
+    let characterSelection: OnboardingProfileCharacterViewModel
+    @Published private(set) var selectedCharacter: String?
+    @AppStorage("hasOnboarded") private var hasOnboarded = false
+    private var cancellables = Set<AnyCancellable>()
+
+    init(characters: [String] = ["chicken", "tiramisu", "croissant", "iceCream"]) {
+        let selection = OnboardingProfileCharacterViewModel(characters: characters)
+        self.characterSelection = selection
+        self.selectedCharacter = selection.selectedCharacter
+
+        selection.$selectedCharacter
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newValue in
+                self?.selectedCharacter = newValue
+            }
+            .store(in: &cancellables)
+    }
+
+    var isNameValid: Bool {
+        let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (2...10).contains(trimmed.count)
+    }
+
+    func reset() {
+        nickname = ""
+        characterSelection.selectedCharacter = nil
+        selectedCharacter = nil
+    }
+
+    func preloadExistingUser(from context: ModelContext) {
+        var descriptor = FetchDescriptor<User>()
+        descriptor.fetchLimit = 1
+
+        if let existing = try? context.fetch(descriptor).first {
+            nickname = existing.nickname
+            characterSelection.selectedCharacter = existing.profileImage
+            selectedCharacter = existing.profileImage
+        }
+    }
+
+    enum OnboardingError: LocalizedError {
+        case invalidNickname
+        case missingCharacter
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidNickname:
+                return "닉네임은 2~10자의 한글, 영문 또는 숫자로 입력해주세요."
+            case .missingCharacter:
+                return "프로필 캐릭터를 선택해주세요."
+            }
+        }
+    }
+
+    func complete(using context: ModelContext) throws {
+        let trimmed = nickname.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard (2...10).contains(trimmed.count) else {
+            throw OnboardingError.invalidNickname
+        }
+        guard let selectedCharacter else {
+            throw OnboardingError.missingCharacter
+        }
+
+        var descriptor = FetchDescriptor<User>()
+        descriptor.fetchLimit = 1
+
+        if let existing = try context.fetch(descriptor).first {
+            existing.nickname = trimmed
+            existing.profileImage = selectedCharacter
+        } else {
+            let user = User(nickname: trimmed, profileImage: selectedCharacter)
+            context.insert(user)
+        }
+
+        try context.save()
+        hasOnboarded = true
+    }
+}

--- a/MenuTaro/MenuTaro/Sources/Views/HomeView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/HomeView.swift
@@ -5,6 +5,25 @@ struct HomeView: View {
     @EnvironmentObject private var router: Router
     @Query(sort: \Bookmark.createdAt, order: .reverse)
     private var bookmarks: [Bookmark]
+    @Query private var users: [User]
+
+    init() {
+        var descriptor = FetchDescriptor<User>()
+        descriptor.fetchLimit = 1
+        _users = Query(descriptor)
+    }
+
+    private var currentUser: User? {
+        users.first
+    }
+
+    private var greetingText: String {
+        if let nickname = currentUser?.nickname, !nickname.isEmpty {
+            return "안녕, \(nickname)!\n오늘은 뭘\n먹어볼까?"
+        } else {
+            return "안녕!\n오늘은 뭘\n먹어볼까?"
+        }
+    }
 
     var body: some View {
         GeometryReader { geo in
@@ -35,16 +54,16 @@ struct HomeView: View {
                 }
                 .padding(.trailing, sidePadding)
 
-                
+
                 HStack(alignment: .center, spacing: w * 0.04) {
-                    Text("안녕!\n오늘은 뭘\n먹어볼까?")
+                    Text(greetingText)
                         .foregroundColor(.white)
                         .font(.system(size: 28, weight: .semibold))
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     ZStack {
                         ProfileCharacterAvatar(
-                            imageName: "chicken",
+                            imageName: currentUser?.profileImage ?? "chicken",
                             diameter: heroCircle,
                             backgroundStyle: ProfileCharacterAvatar.defaultSelectedBackground
                         )
@@ -62,7 +81,6 @@ struct HomeView: View {
                     .frame(width: heroCircle, height: heroCircle)
                 }
                 .padding(.horizontal, sidePadding)
-                .padding(.top, heroSectionSpacing)
 
                 // 기능 카드
                 VStack(spacing: h * 0.012) {

--- a/MenuTaro/MenuTaro/Sources/Views/MypageEditView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/MypageEditView.swift
@@ -1,0 +1,145 @@
+//
+//  MypageEditView.swift
+//  MenuTaro
+//
+//  Created by mac mini on 11/5/25.
+//
+
+
+//
+//  MypageEditView.swift
+//  MenuTaro
+//
+//  Created by mac mini on 11/5/25.
+//
+
+import SwiftUI
+import SwiftData
+
+struct MypageEditView: View {
+    @EnvironmentObject private var router: Router
+    @Environment(\.modelContext) private var modelContext
+    @State private var name: String = ""
+    @StateObject private var viewModel = OnboardingProfileCharacterViewModel()
+    @Query private var users: [User]
+    @State private var errorMessage: String?
+    @State private var didInitialize = false
+
+    init() {
+        var descriptor = FetchDescriptor<User>()
+        descriptor.fetchLimit = 1
+        _users = Query(descriptor)
+    }
+
+    private var currentUser: User? { users.first }
+
+    private var isSaveEnabled: Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (2...10).contains(trimmed.count) && (viewModel.selectedCharacter != nil)
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let metrics = MenuTaroLayoutMetrics.metrics(for: proxy.size)
+
+            ZStack(alignment: .topLeading) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("닉네임")
+                        .font(.system(.title, weight: .bold))
+                        .padding(.leading, proxy.size.width * 0.08)
+                        .foregroundColor(.white)
+
+                    PillTextField(text: $name)
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 32)
+
+                    Text("*닉네임은 한글, 영문, 숫자(2~10)자 이내로 작성해주세요!")
+                        .foregroundColor(.primaryRed)
+                        .font(.system(.caption, weight: .medium))
+                        .padding(.leading, proxy.size.width * 0.1)
+
+                    Text("프로필 캐릭터")
+                        .font(.system(.title, weight: .bold))
+                        .padding(.top, proxy.size.height * 0.03)
+                        .padding(.leading, proxy.size.width * 0.08)
+                        .foregroundColor(.white)
+
+                    ProfileCharacterGrid(viewModel: viewModel)
+                        .frame(minHeight: proxy.size.height * 0.35)
+                        .padding(.bottom, metrics.callToActionHeight + metrics.orangeButtonBottomInset)
+                }
+
+                VStack(spacing: 12) {
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.system(.footnote, weight: .medium))
+                            .foregroundColor(.primaryRed)
+                    }
+
+                    Button("저장") {
+                        saveChanges()
+                    }
+                    .appFont(20, weight: .bold)
+                    .frame(height: metrics.callToActionHeight)
+                    .buttonStyle(OrangeButtonStyle())
+                    .disabled(!isSaveEnabled)
+                    .opacity(isSaveEnabled ? 1 : 0.5)
+                }
+                .padding(.horizontal, metrics.horizontalPadding)
+                .padding(.bottom, metrics.orangeButtonBottomInset)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+
+            }
+        }
+        .background(Color.black)
+        .onAppear(perform: synchronizeUser)
+        .onChange(of: users) { _, _ in
+            synchronizeUser()
+        }
+    }
+}
+
+#Preview {
+    MypageEditView()
+        .environmentObject(Router())
+        .modelContainer(makePreviewContainer())
+}
+
+private extension MypageEditView {
+    func synchronizeUser() {
+        guard !didInitialize, let user = currentUser else { return }
+        name = user.nickname
+        viewModel.selectedCharacter = user.profileImage
+        didInitialize = true
+    }
+
+    func saveChanges() {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard (2...10).contains(trimmed.count) else {
+            errorMessage = OnboardingFlowViewModel.OnboardingError.invalidNickname.errorDescription
+            return
+        }
+
+        guard let selected = viewModel.selectedCharacter else {
+            errorMessage = OnboardingFlowViewModel.OnboardingError.missingCharacter.errorDescription
+            return
+        }
+
+        do {
+            if let user = currentUser {
+                user.nickname = trimmed
+                user.profileImage = selected
+            } else {
+                let user = User(nickname: trimmed, profileImage: selected)
+                modelContext.insert(user)
+            }
+
+            try modelContext.save()
+            errorMessage = nil
+            router.pop()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/MenuTaro/MenuTaro/Sources/Views/MypageView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/MypageView.swift
@@ -9,117 +9,136 @@ import SwiftUI
 import SwiftData
 
 private let hInset: CGFloat = 20
-private let cardSize: CGFloat = 140         // 카드 한 변
 private let rowHeight: CGFloat = 140 + 12
 
 struct MypageView: View {
     @Environment(\.modelContext) private var context
+    @EnvironmentObject private var router: Router
     @StateObject private var vm = MypageViewModel()
+    @Query private var users: [User]
+
+    init() {
+        var descriptor = FetchDescriptor<User>()
+        descriptor.fetchLimit = 1
+        _users = Query(descriptor)
+    }
+
+    private var currentUser: User? { users.first }
+    private var profileImageName: String { currentUser?.profileImage ?? "chicken" }
+    private var nickname: String { currentUser?.nickname ?? "머먹을래" }
 
     var body: some View {
-            ScrollView {
-                VStack(spacing: 20) {
-                    customTopbar(title: "마이페이지")
-                    HStack {
-                        ZStack {
-                            LinearGradient(
-                                colors: [Color(red: 1, green: 0.29, blue: 0.14),
-                                         Color(red: 0.13, green: 0.13, blue: 0.13).opacity(0.8)],
-                                startPoint: .top, endPoint: .bottom
-                            )
-                            .clipShape(Circle())
-                            
-                            Image("chicken")
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 120, height: 120)
-                                .clipShape(Circle())
-                        }
-                        .frame(width: 120, height: 120)
-                        .padding(.leading, 22)
-                        Spacer()
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 153)
-                    .background(Color.white.opacity(0.15))
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
-                    
-                    Button(action: {
-                        print("프로필 편집 버튼 눌림")
-                    }, label: {
-                        Text("프로필 편집")
-                            .font(.system(size: 16, weight: .semibold, design: .default))
+        ScrollView {
+            VStack(spacing: 20) {
+                customTopbar(title: "마이페이지")
+                HStack(alignment: .center, spacing: 16) {
+                    ProfileCharacterAvatar(
+                        imageName: profileImageName,
+                        diameter: 120,
+                        backgroundStyle: ProfileCharacterAvatar.defaultSelectedBackground
+                    )
+                    .padding(.leading, 22)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(nickname)
+                            .font(.system(size: 24, weight: .bold))
                             .foregroundColor(.white)
-                            .frame(maxWidth: .infinity, minHeight: 47)
-                            .background(Color(red: 1, green: 0.29, blue: 0.14))
-                            .clipShape(RoundedRectangle(cornerRadius: 10))
-                    })
-                    
-                    HStack {
-                        Text("7월 랭킹")
-                            .font(.system(size: 20, weight: .bold))
-                            .foregroundColor(.white)
-                        Spacer()
-                        HStack(spacing: 4) {
-                            Text("전체보기")
-                                .font(.system(size: 12, weight: .regular, design: .default))
-                                .foregroundColor(.gray)
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 12))
-                                .foregroundColor(.gray)
-                        }
+
+                        Text("오늘도 맛있는 하루 보내요")
+                            .font(.system(size: 14, weight: .regular))
+                            .foregroundColor(.gray)
                     }
-                    
-                    HStack {
-                        Text("메뉴 랭킹")
-                            .font(.system(size: 14, weight: .medium, design: .default))
-                            .foregroundColor(.white)
-                        Spacer()
-                    }
-                    if vm.menuTop3.isEmpty {
-                        Text("타로카드를 뽑아 음식을 추가해보세요!")
-                            .frame(height: rowHeight)
-                    } else {
-                        ScrollView(.horizontal) {
-                            HStack(spacing: 15) {
-                                ForEach(vm.menuTop3) { item in
-                                    MypageCardView(name: item.food.name, image: item.food.image)
-                                }
-                            }
-                            .padding(.vertical, 6)
-                        }
-                        .frame(height: rowHeight)
-                    }
-                    
-                    HStack {
-                        Text("간식 랭킹")
-                            .font(.system(size: 14, weight: .medium, design: .default))
-                            .foregroundColor(.white)
-                        Spacer()
-                    }
-                    if vm.snackTop3.isEmpty {
-                        Text("포춘쿠키를 뽑아 음식을 추가해보세요!")
-                            .frame(height: rowHeight)
-                    } else {
-                        ScrollView(.horizontal) {
-                            HStack(spacing: 15) {
-                                ForEach(vm.snackTop3) { item in
-                                    MypageCardView(name: item.snack.name, image: item.snack.image)
-                                }
-                            }
-                            .padding(.vertical, 6)
-                        }
-                        .frame(height: rowHeight)
-                    }
+
                     Spacer()
                 }
-                .padding(.horizontal, hInset)
-                .padding(.top, 13)
+                .frame(maxWidth: .infinity, minHeight: 153)
+                .background(Color.white.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+
+                Button(action: {
+                    router.push(.mypageEdit)
+                }, label: {
+                    Text("프로필 편집")
+                        .font(.system(size: 16, weight: .semibold, design: .default))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity, minHeight: 47)
+                        .background(Color(red: 1, green: 0.29, blue: 0.14))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                })
+
+                HStack {
+                    Text("7월 랭킹")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundColor(.white)
+                    Spacer()
+                    HStack(spacing: 4) {
+                        Text("전체보기")
+                            .font(.system(size: 12, weight: .regular, design: .default))
+                            .foregroundColor(.gray)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12))
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                HStack {
+                    Text("메뉴 랭킹")
+                        .font(.system(size: 14, weight: .medium, design: .default))
+                        .foregroundColor(.white)
+                    Spacer()
+                }
+                if vm.menuTop3.isEmpty {
+                    Text("타로카드를 뽑아 음식을 추가해보세요!")
+                        .frame(height: rowHeight)
+                } else {
+                    ScrollView(.horizontal) {
+                        HStack(spacing: 15) {
+                            ForEach(vm.menuTop3) { item in
+                                MypageCardView(name: item.food.name, image: item.food.image)
+                            }
+                        }
+                        .padding(.vertical, 6)
+                    }
+                    .frame(height: rowHeight)
+                }
+
+                HStack {
+                    Text("간식 랭킹")
+                        .font(.system(size: 14, weight: .medium, design: .default))
+                        .foregroundColor(.white)
+                    Spacer()
+                }
+                if vm.snackTop3.isEmpty {
+                    Text("포춘쿠키를 뽑아 음식을 추가해보세요!")
+                        .frame(height: rowHeight)
+                } else {
+                    ScrollView(.horizontal) {
+                        HStack(spacing: 15) {
+                            ForEach(vm.snackTop3) { item in
+                                MypageCardView(name: item.snack.name, image: item.snack.image)
+                            }
+                        }
+                        .padding(.vertical, 6)
+                    }
+                    .frame(height: rowHeight)
+                }
+                Spacer()
             }
-        .onAppear { vm.setContext(context) }
+            .padding(.horizontal, hInset)
+            .padding(.top, 13)
+        }
+        .onAppear {
+            vm.setContext(context)
+            vm.refresh(for: currentUser)
+        }
+        .onChange(of: users) { _, _ in
+            vm.refresh(for: currentUser)
+        }
     }
 }
 
 #Preview {
     MypageView()
         .modelContainer(makePreviewContainer())
+        .environmentObject(Router())
 }

--- a/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
@@ -13,6 +13,9 @@ struct NavigationRootView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var bgStyle: AppBackgroundView.Style = .black
     @State private var didSeedInitialData = false
+    @StateObject private var onboarding = OnboardingFlowViewModel()
+    @AppStorage("hasOnboarded") private var hasOnboarded = false
+    @State private var didTriggerOnboarding = false
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
     var body: some View {
@@ -25,6 +28,7 @@ struct NavigationRootView: View {
             )) {
                 AppView()
                     .environmentObject(router)
+                    .environmentObject(onboarding)
                     .navigationDestination(for: AppRoute.self) { route in
                         destination(for: route)
                     }
@@ -35,6 +39,14 @@ struct NavigationRootView: View {
             withAnimation(.easeInOut) { bgStyle = style }
         }
         .onAppear(perform: seedInitialDataIfNeeded)
+        .onAppear(perform: showOnboardingIfNeeded)
+        .onChange(of: hasOnboarded) { _, newValue in
+            if newValue {
+                didTriggerOnboarding = false
+            } else {
+                showOnboardingIfNeeded()
+            }
+        }
         .preferredColorScheme(.dark)
     }
 
@@ -54,6 +66,13 @@ struct NavigationRootView: View {
                 .navigationTitle("메뉴 타로")
                 .navigationBarTitleDisplayMode(.inline)
                 .environmentObject(router)
+            
+        case let .onboarding(step):
+            onboardingDestination(for: step)
+                .navigationBarBackButtonHidden()
+        case .mypageEdit:
+            MypageEditView()
+                .environmentObject(router)
 
         case let .MenuTaroSelected(foodId):
             MenuTaroSelectedContainer(foodId: foodId)
@@ -63,6 +82,24 @@ struct NavigationRootView: View {
         }
     }
 
+    @ViewBuilder
+    private func onboardingDestination(for step: OnboardingStep) -> some View {
+        switch step {
+        case .name:
+            OnboardingNameSettingView()
+                .environmentObject(router)
+                .environmentObject(onboarding)
+        case .profile:
+            OnboardingProfileCharacter()
+                .environmentObject(router)
+                .environmentObject(onboarding)
+        case .terms:
+            OnboardingTermsView()
+                .environmentObject(router)
+                .environmentObject(onboarding)
+        }
+    }
+    
     @ViewBuilder
     private func snackFortuneDestination(for step: SnackFortuneStep) -> some View {
         switch step {
@@ -110,6 +147,15 @@ extension NavigationRootView {
             print("Failed to seed initial data: \(error)")
             #endif
         }
+    }
+    
+    
+    private func showOnboardingIfNeeded() {
+        guard !hasOnboarded, !didTriggerOnboarding else { return }
+        didTriggerOnboarding = true
+        onboarding.reset()
+        onboarding.preloadExistingUser(from: modelContext)
+        router.replace(with: [.onboarding(step: .name)])
     }
 }
 

--- a/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingNameSettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingNameSettingView.swift
@@ -8,7 +8,14 @@
 import SwiftUI
 
 struct OnboardingNameSettingView: View {
-    @State private var name: String = ""
+    @EnvironmentObject private var router: Router
+    @EnvironmentObject private var onboarding: OnboardingFlowViewModel
+
+    private var isNextEnabled: Bool {
+        onboarding.isNameValid
+    }
+
+
     var body: some View {
         GeometryReader { proxy in
             let metrics = MenuTaroLayoutMetrics.metrics(for: proxy.size)
@@ -28,14 +35,14 @@ struct OnboardingNameSettingView: View {
                         .foregroundColor(.white)
                         .padding(.leading, proxy.size.width * 0.1)
 
-                    PillTextField(text: $name)
+                    PillTextField(text: $onboarding.nickname)
                         .frame(maxWidth: .infinity)
                         .padding(.horizontal, 32)
                 }
                 .padding(.bottom, metrics.callToActionHeight + metrics.orangeButtonBottomInset)
 
                 Button("다음") {
-
+                    router.push(.onboarding(step: .profile))
                 }
                 .appFont(20, weight: .bold)
                 .frame(height: metrics.callToActionHeight)
@@ -43,6 +50,8 @@ struct OnboardingNameSettingView: View {
                 .padding(.horizontal, metrics.horizontalPadding)
                 .padding(.bottom, metrics.orangeButtonBottomInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                .disabled(!isNextEnabled)
+                .opacity(isNextEnabled ? 1 : 0.5)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
@@ -53,4 +62,6 @@ struct OnboardingNameSettingView: View {
 
 #Preview {
     OnboardingNameSettingView()
+        .environmentObject(Router())
+        .environmentObject(OnboardingFlowViewModel())
 }

--- a/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingProfileCharacter.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingProfileCharacter.swift
@@ -8,53 +8,40 @@
 import SwiftUI
 
 struct OnboardingProfileCharacter: View {
-    @StateObject private var viewModel = OnboardingProfileCharacterViewModel()
+    @EnvironmentObject private var router: Router
+    @EnvironmentObject private var onboarding: OnboardingFlowViewModel
+
+    private var isNextEnabled: Bool {
+        onboarding.selectedCharacter != nil
+    }
 
     var body: some View {
         GeometryReader { proxy in
             let metrics = MenuTaroLayoutMetrics.metrics(for: proxy.size)
-            let horizontalPadding = proxy.size.width * 0.1
-            let gridSpacing = proxy.size.width * 0.06
-            let columns: [GridItem] = Array(
-                repeating: GridItem(.flexible(), spacing: gridSpacing),
-                count: 2
-            )
-            let avatarDiameter = (proxy.size.width - (horizontalPadding * 2) - gridSpacing) / 2
+
 
             ZStack(alignment: .topLeading) {
                 VStack(alignment: .leading, spacing: 20) {
                     Text("2/3")
                         .font(.system(.subheadline, weight: .bold))
                         .foregroundColor(.primaryRed)
-
+                        .padding(.horizontal, metrics.horizontalPadding)
+                    
                     Text("프로필 캐릭터를\n선택해주세요.")
                         .font(.system(.title, weight: .bold))
                         .foregroundColor(.white)
-
+                        .padding(.horizontal, metrics.horizontalPadding)
+                    
                     Text("*캐릭터는 언제든지 바꿀 수 있어요!")
                         .font(.system(.caption, weight: .regular))
                         .foregroundColor(.white)
-
-                    LazyVGrid(columns: columns, alignment: .center, spacing: gridSpacing) {
-                        ForEach(viewModel.characters, id: \.self) { character in
-                            let backgroundStyle = viewModel.backgroundStyle(for: character)
-
-                            Button {
-                                viewModel.toggleSelection(for: character)
-                            } label: {
-                                ProfileCharacterAvatar(
-                                    imageName: character,
-                                    diameter: avatarDiameter,
-                                    backgroundStyle: backgroundStyle
-                                )
-                                .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
+                        .padding(.horizontal, metrics.horizontalPadding)
+                    
+                    ProfileCharacterGrid(viewModel: onboarding.characterSelection)
+                        .frame(minHeight: proxy.size.height * 0.35)
+                        .padding(.bottom, metrics.callToActionHeight + metrics.orangeButtonBottomInset)
+                        .padding(.top)
                 }
-                .padding(.horizontal, horizontalPadding)
-                .padding(.bottom, metrics.callToActionHeight + metrics.orangeButtonBottomInset)
 
                 Button("다음") {
 
@@ -65,6 +52,8 @@ struct OnboardingProfileCharacter: View {
                 .padding(.horizontal, metrics.horizontalPadding)
                 .padding(.bottom, metrics.orangeButtonBottomInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                .disabled(!isNextEnabled)
+                .opacity(isNextEnabled ? 1 : 0.5)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
@@ -74,4 +63,6 @@ struct OnboardingProfileCharacter: View {
 
 #Preview {
     OnboardingProfileCharacter()
+        .environmentObject(Router())
+         .environmentObject(OnboardingFlowViewModel())
 }

--- a/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingTermsView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingTermsView.swift
@@ -6,9 +6,14 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct OnboardingTermsView: View {
+    @EnvironmentObject private var router: Router
+    @EnvironmentObject private var onboarding: OnboardingFlowViewModel
+    @Environment(\.modelContext) private var modelContext
     @StateObject private var vm = OnboardingTermsViewModel()
+    @State private var errorMessage: String?
 
     var body: some View {
         GeometryReader { proxy in
@@ -49,23 +54,50 @@ struct OnboardingTermsView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                // 하단 CTA (그대로 유지)
-                Button("시작하기") {
-                    // action
+                VStack(spacing: 12) {
+                     if let errorMessage {
+                         Text(errorMessage)
+                             .font(.system(.footnote, weight: .medium))
+                             .foregroundColor(.primaryRed)
+                     }
+
+                     Button("시작하기") {
+                         startApp()
+                     }
+                     .appFont(20, weight: .bold)
+                     .frame(height: metrics.callToActionHeight)
+                     .buttonStyle(OrangeButtonStyle())
+                     .disabled(!vm.canStart)
+                     .opacity(vm.canStart ? 1 : 0.5)
                 }
-                .appFont(20, weight: .bold)
-                .frame(height: metrics.callToActionHeight)
-                .buttonStyle(OrangeButtonStyle())
                 .padding(.horizontal, metrics.horizontalPadding)
                 .padding(.bottom, metrics.orangeButtonBottomInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
             }
         }
         .background(Color.black)
+        
     }
+    
 }
 
 
+private extension OnboardingTermsView {
+    func startApp() {
+        do {
+            try onboarding.complete(using: modelContext)
+            errorMessage = nil
+            router.popToRoot()
+            router.select(tab: .home)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
 #Preview {
     OnboardingTermsView()
+        .environmentObject(Router())
+        .environmentObject(OnboardingFlowViewModel())
+        .modelContainer(makePreviewContainer())
 }


### PR DESCRIPTION
# 온보딩 & 마이페이지 기능 정리

## 무엇을 했는지?
1. **마이페이지 → 프로필 편집 라우팅 연결**
   - 마이페이지의 "프로필 편집" 버튼에서 `Router`를 이용해 `MypageEditView`로 전환합니다.
   - 온보딩에서 사용하던 캐릭터 그리드를 `ProfileCharacterGrid` 컴포넌트로 분리하여 편집 화면과 온보딩 모두에서 동일한 UI를 재사용합니다.
2. **앱 최초 실행 시 온보딩 플로우 구성**
   - `OnboardingFlowViewModel`을 통해 이름 입력 → 캐릭터 선택 → 약관 동의를 관리하며, 
   - 각 스텝은 `Router`로 양방향 이동이 가능합니다. (추후 상단 툴바 적용으로 구현)
   - 온보딩 완료 시 생성된 `User` 정보를 SwiftData에 저장하고, 저장된 데이터를 홈/마이페이지에서 즉시 표시합니다.

3. 기존 PR에서 폴더 구조 변경이 에러를 유발하여 해당 부분 제거 후 새 PR

## 주요 코드 스니펫
아래 스니펫은 마이페이지에서 프로필 편집 화면으로 라우팅하는 부분입니다.   
전체 구현은 [`Sources/Views/Mypage/MypageView.swift`](../MenuTaro/MenuTaro/Sources/Views/Mypage/MypageView.swift)에서 확인할 수 있습니다.

```swift
Button(action: {
    router.push(.mypageEdit)
}) {
    Text("프로필 편집")
        .font(.system(size: 16, weight: .semibold))
        .foregroundColor(.white)
        .frame(maxWidth: .infinity, minHeight: 47)
        .background(Color(red: 1, green: 0.29, blue: 0.14))
        .clipShape(RoundedRectangle(cornerRadius: 10))
}
.buttonStyle(.plain)
```

온보딩 캐릭터 선택 스텝은 `OnboardingFlowViewModel`의 상태를 공유하여 버튼 활성화 여부를 제어합니다.

```swift
struct OnboardingProfileCharacter: View {
    @EnvironmentObject private var router: Router
    @EnvironmentObject private var onboarding: OnboardingFlowViewModel

    private var isNextEnabled: Bool {
        onboarding.selectedCharacter != nil
    }

    var body: some View {
        VStack {
            ProfileCharacterGrid(viewModel: onboarding.characterSelection)
            Button("다음") {
                router.push(.onboarding(step: .terms))
            }
            .disabled(!isNextEnabled)
            .opacity(isNextEnabled ? 1 : 0.5)
        }
    }
}
```
> 위 코드는 실제 레이아웃에서 핵심 상호작용만 발췌한 축약 버전입니다. 전체 뷰 구성은 [`Sources/Views/Onboarding/OnboardingProfileCharacter.swift`](../MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingProfileCharacter.swift)에서 확인할 수 있습니다.

이 구조를 통해 온보딩 단계에서 선택한 캐릭터 정보가 마이페이지와 홈 화면에 그대로 반영됩니다.

구체적인 동작 방식은 다음과 같습니다.

1. `OnboardingProfileCharacterViewModel`가 selectedCharacter를 @Published로 노출하면,  
캐릭터 버튼을 탭할 때마다 해당 퍼블리셔가 새로운 값을 방출합니다.
```swift
 @Published var selectedCharacter: String?

// ... 기타 코드

func toggleSelection(for character: String) {
    if selectedCharacter == character {
        selectedCharacter = nil
    } else {	
        selectedCharacter = character
}
```

2. `OnboardingFlowViewModel`의 초기화 과정에서 이 퍼블리셔(selection.$selectedCharacter)를 구독하고, 메인 스레드에서 값을 수신하도록 receive(on: DispatchQueue.main)을 지정합니다.  
새 값이 도착하면 sink 클로저가 호출되어 flow 뷰모델의 selectedCharacter를 동기화하며,   
이 구독은 cancellables에 저장되어 생명주기 동안 유지됩니다.  
```swift
init(characters: [String] = ["chicken", "tiramisu", "croissant", "iceCream"]) {
    let selection = OnboardingProfileCharacterViewModel(characters: characters)
    self.characterSelection = selection
    self.selectedCharacter = selection.selectedCharacter

    selection.$selectedCharacter
        .receive(on: DispatchQueue.main)
        .sink { [weak self] newValue in
            self?.selectedCharacter = newValue
        }
        .store(in: &cancellables)
```

3. 결과적으로 온보딩 2단계에서 캐릭터를 고르면 selectedCharacter가 즉시 업데이트되어 
“다음” 버튼 활성화 조건과 같은 UI 상태가 즉각 반응하게 됩니다.

```swift
selection.$selectedCharacter
    .receive(on: DispatchQueue.main)
    .sink { [weak self] newValue in
        self?.selectedCharacter = newValue
    }
    .store(in: &cancellables)
```

관련 이슈
https://github.com/ParkChanHwi/MenuTaro/issues/23