### PR TITLE
[Feat]#30 - 온보딩 타이틀 백버튼 구현

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
@@ -73,6 +73,9 @@ struct NavigationRootView: View {
         case .mypageEdit:
             MypageEditView()
                 .environmentObject(router)
+                .customToolbar(title: "프로필 편집") {
+                    router.pop()
+                }
 
         case let .MenuTaroSelected(foodId):
             MenuTaroSelectedContainer(foodId: foodId)

--- a/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NavigationRootView.swift
@@ -89,14 +89,22 @@ struct NavigationRootView: View {
             OnboardingNameSettingView()
                 .environmentObject(router)
                 .environmentObject(onboarding)
+                .customToolbar(title: "", showBackButton: false) {
+                }
         case .profile:
             OnboardingProfileCharacter()
                 .environmentObject(router)
                 .environmentObject(onboarding)
+                .customToolbar(title: "") {
+                    router.pop()
+                }
         case .terms:
             OnboardingTermsView()
                 .environmentObject(router)
                 .environmentObject(onboarding)
+                .customToolbar(title: "") {
+                    router.pop()
+                }
         }
     }
     

--- a/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingProfileCharacter.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingProfileCharacter.swift
@@ -44,7 +44,7 @@ struct OnboardingProfileCharacter: View {
                 }
 
                 Button("다음") {
-
+                    router.push(.onboarding(step: .terms))
                 }
                 .appFont(20, weight: .bold)
                 .frame(height: metrics.callToActionHeight)
@@ -64,5 +64,5 @@ struct OnboardingProfileCharacter: View {
 #Preview {
     OnboardingProfileCharacter()
         .environmentObject(Router())
-         .environmentObject(OnboardingFlowViewModel())
+        .environmentObject(OnboardingFlowViewModel())
 }


### PR DESCRIPTION
수정사항
- NavigationRootView 내부에서 온보딩 스텝에 CustomToolVar 추가
- 온보딩 프로필 캐릭터 선택 화면에서 다음 버튼 동작 구현
- 마이페이지 프로필 편집 화면에서 상단 타이틀 및 백버튼 CustomToolBar 적용

관련 문서
> [노션-온보딩타이틀](https://www.notion.so/2a2b793cb89e804bba82c695e796e8c9?source=copy_link)

이슈
>[이슈-30](https://github.com/ParkChanHwi/MenuTaro/issues/30)