### PR TITLE
[Feat] #35 - 로컬 푸시 알림 구현하기

### DIFF
--- a/MenuTaro/MenuTaro/MenuTaro.entitlements
+++ b/MenuTaro/MenuTaro/MenuTaro.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/MenuTaro/MenuTaro/Sources/Models/NotificationMessage.swift
+++ b/MenuTaro/MenuTaro/Sources/Models/NotificationMessage.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct NotificationMessage {
+    let title: String
+    let body: String
+}
+
+// 알림 메시지 목록 데이터
+let menuNotifications: [NotificationMessage] = [
+    NotificationMessage(title: "오늘의 메뉴 추천", body: "한식"),
+    NotificationMessage(title: "오늘의 메뉴 추천", body: "중식"),
+    NotificationMessage(title: "오늘의 메뉴 추천", body: "양식"),
+    NotificationMessage(title: "오늘의 메뉴 추천", body: "일식"),
+    NotificationMessage(title: "오늘의 메뉴 추천", body: "분식")
+]

--- a/MenuTaro/MenuTaro/Sources/Utils/AppDelegate.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/AppDelegate.swift
@@ -3,7 +3,12 @@ import UIKit
 class AppDelegate: NSObject, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        print("AppDelegate 성공")
+        
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            print(granted, error)
+        }
         return true
     }
     
@@ -11,5 +16,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let sceneConfig = UISceneConfiguration(name: "Default Coniguration", sessionRole: connectingSceneSession.role)
         sceneConfig.delegateClass = SceneDelegate.self
         return sceneConfig
+    }
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.sound, .badge, .banner])
     }
 }

--- a/MenuTaro/MenuTaro/Sources/Utils/SceneDelegate.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/SceneDelegate.swift
@@ -11,9 +11,40 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
         let rootView = NavigationRootView()
             .environmentObject(Router())
             .modelContainer(for: [User.self, Snack.self, FoodCard.self, ConsumptionRecord.self, Bookmark.self])
-
+        
         window.rootViewController = UIHostingController(rootView: rootView)
         self.window = window
         window.makeKeyAndVisible()
+        
+        sendNotificationMessage()
+    }
+    
+    func sendNotificationMessage() {
+        guard let randomMessage = menuNotifications.randomElement() else {
+            print("알림 메시지 목록이 비어있습니다.")
+            return
+        }
+        
+        let content = UNMutableNotificationContent()
+        
+        content.title = randomMessage.title
+        content.body = randomMessage.body
+        content.sound = .default
+        
+        // 실행 후 3초 후 알림
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 3, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: trigger
+        )
+        
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("알림 등록 실패: \(error.localizedDescription)")
+            } else {
+                print("알림 등록 완료")
+            }
+        }
     }
 }


### PR DESCRIPTION
# 무엇을 했는지?
로컬 푸시 알림을 구현했습니다.

## 팀원들에게 알릴 사항
해당 앱이 켜져 있을 때도 푸시 알림을 나타나게 하는지? 아니면 앱이 켜져 있을 땐 푸시 알림이 나타나지 않게 하는지?
현재 코드는 앱이 켜져 있을 때도 푸시 알림이 나타나게 구현되어 있습니다. 
```swift
completionHandler([.sound, .badge, .banner])
```

## 관련 이슈
#35 

## 노션
[AppDelegate, SceneDelegate 생성](https://www.notion.so/AppDelegate-SceneDelegate-2a4b793cb89e804fad61ff24dc163697)
[로컬 푸시 알림 기능 구현하기](https://www.notion.so/2a2b793cb89e8145a6c4f4f4a27ed33f)