### PR TITLE
[Feat] #49 알림 설정 토글 여부에 따른 앱 푸시 알림 연동

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
@@ -13,8 +13,7 @@ struct NotiSettingView: View {
             Text("푸시 알림")
                 .font(.system(size: 18, weight: .medium))
         
-            Toggle("앱 알림", isOn: $appNotiToggle)
-                .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
+            NotificationPermissionToggleView()
             
             Toggle(isOn: $nightAppNotiToggle) {
                 Text("야간 알림")

--- a/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import UserNotifications
+
+struct NotificationPermissionToggleView: View {
+    @State private var isNotificationEnabled = false
+    
+    var body: some View {
+        Toggle("앱 알림", isOn: $isNotificationEnabled)
+            .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
+            .onChange(of: isNotificationEnabled) { newValue in
+                if newValue {
+                    
+                } else {
+                    isNotificationEnabled = false
+                }
+            }
+            .onAppear {
+                checkPermission()
+            }
+    }
+    
+    private func requestPermission() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
+            DispatchQueue.main.async {
+                isNotificationEnabled = granted
+            }
+        }
+    }
+    
+    private func checkPermission() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                isNotificationEnabled = (settings.authorizationStatus == .authorized)
+            }
+        }
+    }
+}

--- a/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
@@ -9,16 +9,20 @@ struct NotificationPermissionToggleView: View {
             .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
             .onChange(of: isNotificationEnabled) { newValue in
                 if newValue {
-                    
+                    self.requestOrNavigateToSettings()
                 } else {
-                    isNotificationEnabled = false
+                    // 알림 허용안함 -> 설정으로
+                    navigateToSeetings()
+                    checkPermission()
                 }
             }
+        // 현재 알림 권한 상태 확인
             .onAppear {
                 checkPermission()
             }
     }
     
+    // 알림 권한 요청 팝업
     private func requestPermission() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
             DispatchQueue.main.async {
@@ -27,10 +31,43 @@ struct NotificationPermissionToggleView: View {
         }
     }
     
+    // 현재 알림 설정을 가져옴
     private func checkPermission() {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
                 isNotificationEnabled = (settings.authorizationStatus == .authorized)
+            }
+        }
+    }
+    
+    private func requestOrNavigateToSettings() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                switch settings.authorizationStatus {
+                // 최초 요청
+                case .notDetermined:
+                    self.requestPermission()
+                case .denied:
+                    // 권한이 거부되어 있는 상태
+                    self.navigateToSeetings()
+                    isNotificationEnabled = false
+                case .authorized, .provisional, .ephemeral:
+                    // 이미 권한 있으면 토글 켜진 상태로 유지
+                    isNotificationEnabled = true
+                @unknown default:
+                    isNotificationEnabled = false
+                }
+            }
+        }
+    }
+    
+    private func navigateToSeetings() {
+        // 토글 누르면 설정으로 이동하게 안내
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url) { success in
+                if !success {
+                    print("Could not open settings")
+                }
             }
         }
     }


### PR DESCRIPTION
# 무엇을 했는지?
- 알림 권한 알럿 허용/허용안함에 따라 토글 상태 true/false를 연동했습니다.
- 알림 토글 변환 시 시스템 설정 화면으로 이동해 사용자가 직접 알림 허용/허용안함을 설정할 수 있게 했습니다.
<br>

### 알림 권한 알럿에서 **허용**을 눌렀을 때 저장되는 알림 토글 상태
<img width="250" height="550" alt="image" src="https://github.com/user-attachments/assets/fdbf7824-01a6-477c-b082-1a1a9cf77f3e" />

<br>

### 알림 토글 **off -> on**으로 변경
<img width="250" height="550" alt="image" src="https://github.com/user-attachments/assets/cd44eeab-294e-4842-9fd9-cab38635776c" />

## 관련 이슈
#49 

## 노션_개발일지
[알림 설정 토글 여부에 따른 앱 푸시 알림 연동](https://pewter-pint-0bf.notion.site/2a8b793cb89e8044930fde24303639c0?source=copy_link)