### PR TITLE
[Feat] #64 - 앱이 실행 중일 때 푸시 알림 안뜨게

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Utils/SceneDelegate.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/SceneDelegate.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-class SceneDelegate: NSObject, UIWindowSceneDelegate {
+class SceneDelegate: NSObject, UIWindowSceneDelegate, UNUserNotificationCenterDelegate {
     
     var window: UIWindow?
     
@@ -15,6 +15,8 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
         window.rootViewController = UIHostingController(rootView: rootView)
         self.window = window
         window.makeKeyAndVisible()
+        
+        UNUserNotificationCenter.current().delegate = self
         
         sendNotificationMessage()
     }
@@ -46,5 +48,11 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
                 print("알림 등록 완료")
             }
         }
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        // 앱이 foreground일 때는 아무것도 표시 X
+        completionHandler([])
     }
 }


### PR DESCRIPTION
# 무엇을 했는지?
- 백그라운드 상태에서는 3초 후 푸시 알림을 띄우게 유지했고, 포그라운드 상태에서는 푸시 알림을 띄우지 않게 수정했습니다.

![Simulator Screen Recording - iPhone 16 - 2025-11-19 at 00 11 25](https://github.com/user-attachments/assets/f10d2fb6-4e8d-4c94-b832-54dbcf00cd7c)



## 팀원들에게 알릴 사항

## 관련 이슈
#64 

## 노션_개발일지
[앱이 실행 중일 땐 푸시 알림 안뜨게](https://www.notion.so/2a8b793cb89e80d1bd46d7f1774eadfc)
