### PR TITLE
[Chore]#56 - RankingView 정렬 방식 수정

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Views/RankingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/RankingView.swift
@@ -74,13 +74,12 @@ struct RankingView: View {
                         }
                         .padding(.horizontal, hInset)
                     }
-                    
                 default:
                     EmptyView()
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear {
             vm.setContext(context)
             vm.fetchMenuTop3(limit: 10)
@@ -91,6 +90,5 @@ struct RankingView: View {
 
 #Preview {
     RankingView()
-        .background(Color.black)
-        .modelContainer(makePreviewContainer())
+       
 }


### PR DESCRIPTION
# 무엇을 했는지?

기존 중앙에서부터 추가하며 올라가는 식의 방식에서 상단정렬 방식으로 수정함.
중앙정렬 -> 상단정렬

alignment: .center -> alignment: .top

#56