### PR TITLE
[Chore] #66 - 마케팅 수신 동의 토글 주석 처리

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotiSettingView.swift
@@ -15,13 +15,11 @@ struct NotiSettingView: View {
         
             NotificationPermissionToggleView()
             
-            Toggle(isOn: $nightAppNotiToggle) {
-                Text("야간 알림")
-                    .font(.system(size: 16))
-                + Text("(21시~08시)")
-                    .font(.system(size: 16))
-                    .foregroundColor(.gray)
-            }
+            // 추후 기능 추가 할 예정
+//            Toggle(isOn: $nightAppNotiToggle) {
+//                Text("마케팅 수신 동의")
+//                    .font(.system(size: 16))
+//            }
                 .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
         }
         .padding(.leading, 40)


### PR DESCRIPTION
# 무엇을 했는지?
- 마케팅 수신 동의 토글을 주석 처리하여 UI에서 제거했다.
-> 마케팅 수신 관련 기능이 아직 없기 때문에 추후에 추가 에정 

<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/74131094-bb3a-4202-9957-4179b0959f4b" />

## 팀원들에게 알릴 사항
X

## 관련 이슈
#66  
