### PR TITLE
[Chore] #71 - 간식 카테고리 UI 수정 및 버튼 비활성화

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Components/GradientCardView.swift
+++ b/MenuTaro/MenuTaro/Sources/Components/GradientCardView.swift
@@ -38,7 +38,7 @@ struct GradientCardView<Content: View>: View {
                 )
             } else {
                 // 비활성화 상태일 때는 회색 단색 배경
-                Color.gray.opacity(0.8)
+                Color.secondary.opacity(0.4)
             }
         }
         .frame(width: width, height: height)

--- a/MenuTaro/MenuTaro/Sources/Views/HomeView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/HomeView.swift
@@ -82,14 +82,14 @@ struct HomeView: View {
 
                     // 간식 포춘쿠키 카드
                     Button {
-                        router.push(.snackFortune(step: .selection))
+//                        router.push(.snackFortune(step: .selection))
                     } label: {
-                        GradientCardView(width: gradientCardW, height: gradientCardH) {
+                        GradientCardView(width: gradientCardW, height: gradientCardH, isActive: false) {
                             HStack {
-                                Text("간식 포춘쿠키")
+                                Text("추후 오픈 예정")
                                     .font(.system(size: 18, weight: .medium))
                                     .foregroundColor(.white)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .frame(maxWidth: .infinity, alignment: .center)
 
                                 Image("cookie_broken_home")
                                     .resizable()

--- a/MenuTaro/MenuTaro/Sources/Views/HomeView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/HomeView.swift
@@ -98,6 +98,7 @@ struct HomeView: View {
                                         width: gradientCardW * 0.565,
                                         height: gradientCardH * 1.225
                                     )
+                                    .opacity(0.05)
                             }
                             .padding(.leading, gradientInternalLeading)
                             .padding(.bottom, gradientCardH * 0.097)


### PR DESCRIPTION
# 무엇을 했는지?
간식 카테고리 UI를 수정했습니다. (간식 메뉴 타로 -> 추후 오픈 예정 / 배경색 좀 더 자연러운 회색으로 수정 / 간식 카테고리임을 알리기 위해 이미지는 보존하고 불투명 적용)
<br>

![Simulator Screen Recording - iPhone 16 - 2025-11-20 at 21 42 00](https://github.com/user-attachments/assets/83e16914-d9a3-4a52-90db-0a4d5dae9f49)

## 팀원들에게 알릴 사항
버튼 탭을 아예 막아봤는데 부자연스러운 느낌이 있어 탭 효과는 존재하지만 화면이 이동되지 않게 수정했습니다.

## 관련 개발일지
[간식 카테고리 UI 수정 및 버튼 비활성화](https://www.notion.so/UI-2afb793cb89e80ffa19cc2ef6e65c6f5)

## 관련 이슈
#71 
