### PR TITLE
[Feat] #60 - 푸시 알림 시간 설정

### DIFF
--- a/MenuTaro/MenuTaro/Sources/Utils/AppDelegate.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/AppDelegate.swift
@@ -1,14 +1,34 @@
 import UIKit
+import UserNotifications
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        
         let center = UNUserNotificationCenter.current()
         center.delegate = self
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            print(granted, error)
+
+        let notificationManager = NotificationManager.shared
+
+        notificationManager.fetchAuthorizationStatus { status in
+            switch status {
+            case .authorized, .provisional:
+                print("[AppDelegate] 기존 권한으로 알림 스케줄링 시작")
+                notificationManager.scheduleDailyNotification()
+
+            case .notDetermined:
+                print("[AppDelegate] 권한 미확인 상태, 요청 진행")
+                notificationManager.requestNotificatonAuthorization { granted in
+                    print("[AppDelegate] 권한 요청 결과: \(granted)")
+                    if granted {
+                        notificationManager.scheduleDailyNotification()
+                    }
+                }
+
+            default:
+                print("[AppDelegate] 알림 권한 거부 상태")
+            }
         }
+
         return true
     }
     

--- a/MenuTaro/MenuTaro/Sources/Utils/NotificationManager.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/NotificationManager.swift
@@ -1,3 +1,4 @@
+// NotificationManager.swift
 import SwiftUI
 import UserNotifications
 
@@ -17,5 +18,46 @@ class NotificationManager {
                 print("사용자가 알림 권한 거부")
             }
         }
+    }
+    
+    func scheduleDailyNotification() {
+        let center = UNUserNotificationCenter.current()
+        
+        center.removeAllPendingNotificationRequests()
+        
+        let times: [(hour: Int, minute: Int, title: String, body: String)] = [
+            (8, 0, "아침 알림", "아침 드세요!"),
+            (12, 0, "점실 알림", "점심 드세요!"),
+            (18, 0, "저녁 알림", "저녁 드세요!")
+        ]
+        
+        for time in times {
+            scheduleNotification(
+                hour: time.hour,
+                minute: time.minute,
+                title: time.title,
+                body: time.body
+            )
+        }
+    }
+    
+    private func scheduleNotification(hour: Int, minute: Int, title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        
+        var dateComponents = DateComponents()
+        dateComponents.hour = hour
+        dateComponents.minute = minute
+        
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+        
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: trigger
+        )
+        UNUserNotificationCenter.current().add(request)
     }
 }

--- a/MenuTaro/MenuTaro/Sources/Utils/NotificationManager.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/NotificationManager.swift
@@ -60,7 +60,7 @@ class NotificationManager {
 
             let times: [(identifier: String, hour: Int, minute: Int, title: String, body: String)] = [
                 (self.dailyNotificationIdentifiers[0], 8, 0, "아침 알림", "아침 드세요!"),
-                (self.dailyNotificationIdentifiers[1], 12, 0, "점실 알림", "점심 드세요!"),
+                (self.dailyNotificationIdentifiers[1], 12, 0, "점심 알림", "점심 드세요!"),
                 (self.dailyNotificationIdentifiers[2], 18, 0, "저녁 알림", "저녁 드세요!")
             ]
 

--- a/MenuTaro/MenuTaro/Sources/Utils/NotificationManager.swift
+++ b/MenuTaro/MenuTaro/Sources/Utils/NotificationManager.swift
@@ -4,12 +4,26 @@ import UserNotifications
 
 class NotificationManager {
     static let shared = NotificationManager()
-    
-    func requestNotificatonAuthorization() {
+
+    private let notificationCenter = UNUserNotificationCenter.current()
+    private lazy var logDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.timeZone = .current
+        return formatter
+    }()
+
+    private let dailyNotificationIdentifiers = [
+        "morning_notification",
+        "lunch_notification",
+        "dinner_notification"
+    ]
+
+    func requestNotificatonAuthorization(completion: @escaping (Bool) -> Void) {
         // 알림 권한 요청 (알림, 소리, 배지)
         let options: UNAuthorizationOptions = [.alert, .sound, .badge]
-        
-        UNUserNotificationCenter.current().requestAuthorization(options: options) { success, error in
+
+        notificationCenter.requestAuthorization(options: options) { success, error in
             if let error {
                 print("알림 권한 요청 오류: \(error)")
             } else if success {
@@ -17,47 +31,122 @@ class NotificationManager {
             } else {
                 print("사용자가 알림 권한 거부")
             }
+
+            DispatchQueue.main.async {
+                completion(success)
+            }
         }
     }
-    
+
+    func fetchAuthorizationStatus(completion: @escaping (UNAuthorizationStatus) -> Void) {
+        notificationCenter.getNotificationSettings { settings in
+            print("현재 알림 권한 상태: \(settings.authorizationStatus.rawValue)")
+            DispatchQueue.main.async {
+                completion(settings.authorizationStatus)
+            }
+        }
+    }
+
     func scheduleDailyNotification() {
-        let center = UNUserNotificationCenter.current()
-        
-        center.removeAllPendingNotificationRequests()
-        
-        let times: [(hour: Int, minute: Int, title: String, body: String)] = [
-            (8, 0, "아침 알림", "아침 드세요!"),
-            (12, 0, "점실 알림", "점심 드세요!"),
-            (18, 0, "저녁 알림", "저녁 드세요!")
-        ]
-        
-        for time in times {
-            scheduleNotification(
-                hour: time.hour,
-                minute: time.minute,
-                title: time.title,
-                body: time.body
-            )
+        notificationCenter.getNotificationSettings { [weak self] settings in
+            guard let self else { return }
+
+            guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+                print("알림 권한이 없어 스케줄링하지 않음")
+                return
+            }
+
+            print("일일 알림 스케줄링 시작")
+
+            let times: [(identifier: String, hour: Int, minute: Int, title: String, body: String)] = [
+                (self.dailyNotificationIdentifiers[0], 8, 0, "아침 알림", "아침 드세요!"),
+                (self.dailyNotificationIdentifiers[1], 12, 0, "점실 알림", "점심 드세요!"),
+                (self.dailyNotificationIdentifiers[2], 18, 0, "저녁 알림", "저녁 드세요!")
+            ]
+
+            self.notificationCenter.removePendingNotificationRequests(withIdentifiers: self.dailyNotificationIdentifiers)
+            print("기존 일일 알림 제거: \(self.dailyNotificationIdentifiers)")
+            self.logPendingNotifications(context: "after removePendingNotificationRequests")
+
+            for time in times {
+                self.scheduleNotification(
+                    identifier: time.identifier,
+                    hour: time.hour,
+                    minute: time.minute,
+                    title: time.title,
+                    body: time.body
+                )
+            }
+
+            self.logPendingNotifications(context: "after scheduleDailyNotification")
         }
     }
-    
-    private func scheduleNotification(hour: Int, minute: Int, title: String, body: String) {
+
+    func removeDailyNotifications() {
+        notificationCenter.removePendingNotificationRequests(withIdentifiers: dailyNotificationIdentifiers)
+    }
+
+    private func scheduleNotification(
+        identifier: String,
+        hour: Int,
+        minute: Int,
+        title: String,
+        body: String
+    ) {
+        print("알림 예약 시도: identifier=\(identifier), 시간=\(String(format: "%02d:%02d", hour, minute))")
+
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = .default
-        
+
         var dateComponents = DateComponents()
+        dateComponents.calendar = Calendar.current
+        dateComponents.timeZone = .current
         dateComponents.hour = hour
         dateComponents.minute = minute
-        
+
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
-        
+
         let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
+            identifier: identifier,
             content: content,
             trigger: trigger
         )
-        UNUserNotificationCenter.current().add(request)
+        notificationCenter.add(request) { error in
+            if let error {
+                print("알림 예약 실패: \(error.localizedDescription)")
+            } else {
+                let nextDate = (trigger as? UNCalendarNotificationTrigger)?.nextTriggerDate()
+                let formattedDate = nextDate.map { self.logDateFormatter.string(from: $0) } ?? "unknown"
+                print("알림 예약 완료: identifier=\(identifier), 다음 트리거=\(formattedDate)")
+            }
+        }
+    }
+
+    private func logPendingNotifications(context: String) {
+        notificationCenter.getPendingNotificationRequests { [weak self] requests in
+            guard let self else { return }
+
+            print("[알림 로그][\(context)] 대기 중 알림 개수: \(requests.count)")
+
+            for request in requests {
+                let triggerDescription = self.describe(trigger: request.trigger)
+                print("- identifier=\(request.identifier), trigger=\(triggerDescription)")
+            }
+        }
+    }
+
+    private func describe(trigger: UNNotificationTrigger?) -> String {
+        guard let trigger else { return "없음" }
+
+        if let calendarTrigger = trigger as? UNCalendarNotificationTrigger {
+            let hour = calendarTrigger.dateComponents.hour ?? -1
+            let minute = calendarTrigger.dateComponents.minute ?? -1
+            let nextDate = calendarTrigger.nextTriggerDate().map { logDateFormatter.string(from: $0) } ?? "알 수 없음"
+            return "캘린더 트리거 (시간=\(String(format: "%02d:%02d", hour, minute)), 다음 트리거=\(nextDate))"
+        }
+
+        return String(describing: type(of: trigger))
     }
 }

--- a/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
@@ -16,7 +16,6 @@ struct NotificationPermissionToggleView: View {
                     notificationManager.removeDailyNotifications()
                     // 알림 허용안함 -> 설정으로
                     navigateToSeetings()
-                    checkPermission()
                 }
             }
         // 현재 알림 권한 상태 확인

--- a/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 import UserNotifications
 
 struct NotificationPermissionToggleView: View {
+    private let notificationManager = NotificationManager.shared
     @State private var isNotificationEnabled = false
-    
+
     var body: some View {
         Toggle("앱 알림", isOn: $isNotificationEnabled)
             .toggleStyle(SwitchToggleStyle(tint: Color.primaryRed))
@@ -12,6 +13,7 @@ struct NotificationPermissionToggleView: View {
                 if newValue {
                     self.requestOrNavigateToSettings()
                 } else {
+                    notificationManager.removeDailyNotifications()
                     // 알림 허용안함 -> 설정으로
                     navigateToSeetings()
                     checkPermission()
@@ -22,47 +24,47 @@ struct NotificationPermissionToggleView: View {
                 checkPermission()
             }
     }
-    
+
     // 알림 권한 요청 팝업
     private func requestPermission() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
-            DispatchQueue.main.async {
-                isNotificationEnabled = granted
-                
-                if granted {
-                    NotificationManager.shared.scheduleDailyNotification()
-                }
+        notificationManager.requestNotificatonAuthorization { granted in
+            isNotificationEnabled = granted
+
+            if granted {
+                notificationManager.scheduleDailyNotification()
+            } else {
+                notificationManager.removeDailyNotifications()
             }
         }
     }
-    
+
     // 현재 알림 설정을 가져옴
     private func checkPermission() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            DispatchQueue.main.async {
-                isNotificationEnabled = (settings.authorizationStatus == .authorized)
+        notificationManager.fetchAuthorizationStatus { status in
+            switch status {
+            case .authorized, .provisional:
+                isNotificationEnabled = true
+            default:
+                isNotificationEnabled = false
             }
         }
     }
     
     private func requestOrNavigateToSettings() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            DispatchQueue.main.async {
-                switch settings.authorizationStatus {
-                // 최초 요청
-                case .notDetermined:
-                    self.requestPermission()
-                case .denied:
-                    // 권한이 거부되어 있는 상태
-                    self.navigateToSeetings()
-                    isNotificationEnabled = false
-                case .authorized, .provisional, .ephemeral:
-                    // 이미 권한 있으면 토글 켜진 상태로 유지
-                    isNotificationEnabled = true
-                    NotificationManager.shared.scheduleDailyNotification()
-                @unknown default:
-                    isNotificationEnabled = false
-                }
+        notificationManager.fetchAuthorizationStatus { status in
+            switch status {
+            case .notDetermined:
+                self.requestPermission()
+            case .denied:
+                // 권한이 거부되어 있는 상태
+                self.navigateToSeetings()
+                isNotificationEnabled = false
+            case .authorized, .provisional, .ephemeral:
+                // 이미 권한 있으면 토글 켜진 상태로 유지
+                isNotificationEnabled = true
+                notificationManager.scheduleDailyNotification()
+            @unknown default:
+                isNotificationEnabled = false
             }
         }
     }

--- a/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/NotificationPermissionToggleView.swift
@@ -1,3 +1,4 @@
+// NotificationPermissionToggleView.swift
 import SwiftUI
 import UserNotifications
 
@@ -27,6 +28,10 @@ struct NotificationPermissionToggleView: View {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
             DispatchQueue.main.async {
                 isNotificationEnabled = granted
+                
+                if granted {
+                    NotificationManager.shared.scheduleDailyNotification()
+                }
             }
         }
     }
@@ -54,6 +59,7 @@ struct NotificationPermissionToggleView: View {
                 case .authorized, .provisional, .ephemeral:
                     // 이미 권한 있으면 토글 켜진 상태로 유지
                     isNotificationEnabled = true
+                    NotificationManager.shared.scheduleDailyNotification()
                 @unknown default:
                     isNotificationEnabled = false
                 }

--- a/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingNameSettingView.swift
+++ b/MenuTaro/MenuTaro/Sources/Views/Onboarding/OnboardingNameSettingView.swift
@@ -60,7 +60,11 @@ struct OnboardingNameSettingView: View {
 
         // 알림 권한 띄우는
         .onAppear {
-            notiManager.requestNotificatonAuthorization()
+            notiManager.requestNotificatonAuthorization { granted in
+                if granted {
+                    notiManager.scheduleDailyNotification()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# 알림 관련 코드 변경 설명

앱 시작 시부터 온보딩, 설정 화면까지 알림 흐름을 한눈에 볼 수 있도록 최근 수정된 코드의 역할과 동작 과정을 정리했습니다.

## AppDelegate
- 앱이 실행되면 `UNUserNotificationCenter` 델리게이트를 설정하고, `NotificationManager`를 통해 권한 상태를 조회합니다.
- 권한이 이미 있으면 즉시 `scheduleDailyNotification()`으로 일일 알림을 등록합니다.
- 권한이 결정되지 않은 경우 팝업을 띄워 승인 여부를 받고, 승인 시 동일하게 알림을 스케줄링합니다.
- 거부된 상태면 추가 작업 없이 로그만 남깁니다.

## NotificationManager
- 알림 권한 요청(`requestNotificatonAuthorization`)과 현재 상태 조회(`fetchAuthorizationStatus`)를 중앙에서 처리합니다.
- `scheduleDailyNotification()`은 권한 상태를 다시 확인한 뒤, 기존 일일 알림을 식별자 단위로 제거하고 아침/점심/저녁(08:00, 12:00, 18:00) 반복 알림을 새로 등록합니다.
- 각 예약 시도와 다음 트리거 시간을 로그로 남겨 알림이 실제로 큐에 올라갔는지 추적할 수 있습니다.
- `removeDailyNotifications()`는 동일한 식별자 배열로 대기 중 알림을 제거해 토글 OFF나 설정 변경 시 일괄 해제합니다.

## NotificationPermissionToggleView
- 토글 ON 시 현재 권한을 확인하여: 미결정이면 권한 팝업을 띄우고, 거부 상태면 설정 앱으로 이동을 유도합니다. 권한이 이미 있거나 방금 승인되면 `scheduleDailyNotification()`을 호출해 일일 알림을 즉시 예약합니다.
- 토글 OFF 시 `removeDailyNotifications()`로 예약을 지우고 설정 화면으로 이동을 안내합니다.
- `onAppear`에서 권한을 조회해 토글 상태를 실시간 권한과 동기화합니다.

## OnboardingNameSettingView
- 온보딩 첫 화면 진입 시 권한을 요청하고, 사용자가 허용하면 바로 `scheduleDailyNotification()`을 호출해 앱 초기 설정 단계에서 알림이 등록되도록 합니다.
- 권한 거부 시에는 알림을 스케줄링하지 않고 다음 온보딩 단계로만 진행합니다.

#관련 이슈
#60 

# 관련 노션  
[푸시 알림 시간 설정](https://www.notion.so/2afb793cb89e80cc9242dd404fa8a161)

#테스트
테스트 기기 : iPhone 12Pro  

테스트 결과
<img width="1170" height="2532" alt="IMG_6275" src="https://github.com/user-attachments/assets/42dca403-d86f-49c7-8ea1-f9e41d976029" />


#App Delegate 로그
```
[AppDelegate] 기존 권한으로 알림 스케줄링 시작
일일 알림 스케줄링 시작
기존 일일 알림 제거: ["morning_notification", "lunch_notification", "dinner_notification"]
알림 예약 시도: identifier=morning_notification, 시간=08:00
알림 예약 시도: identifier=lunch_notification, 시간=16:42
알림 예약 시도: identifier=dinner_notification, 시간=18:00
[알림 로그][after removePendingNotificationRequests] 대기 중 알림 개수: 4
- identifier=2C0255FC-C748-4681-A91F-0CDE33ACBD6D, trigger=캘린더 트리거 (시간=08:00, 다음 트리거=2025-11-22 08:00:00)
- identifier=CC14A869-CAB8-49FD-90EC-6F73D5BF1BAB, trigger=캘린더 트리거 (시간=12:00, 다음 트리거=2025-11-22 12:00:00)
- identifier=982A2231-651D-4640-8761-6A75EEB02E61, trigger=캘린더 트리거 (시간=18:00, 다음 트리거=2025-11-21 18:00:00)
- identifier=F63BC6C6-5E66-4999-8497-E4DC057DE6C9, trigger=UNTimeIntervalNotificationTrigger
알림 예약 완료: identifier=morning_notification, 다음 트리거=2025-11-22 08:00:00
알림 예약 완료: identifier=lunch_notification, 다음 트리거=2025-11-21 16:42:00
알림 예약 완료: identifier=dinner_notification, 다음 트리거=2025-11-21 18:00:00
[알림 로그][after scheduleDailyNotification] 대기 중 알림 개수: 7
- identifier=2C0255FC-C748-4681-A91F-0CDE33ACBD6D, trigger=캘린더 트리거 (시간=08:00, 다음 트리거=2025-11-22 08:00:00)
- identifier=CC14A869-CAB8-49FD-90EC-6F73D5BF1BAB, trigger=캘린더 트리거 (시간=12:00, 다음 트리거=2025-11-22 12:00:00)
- identifier=982A2231-651D-4640-8761-6A75EEB02E61, trigger=캘린더 트리거 (시간=18:00, 다음 트리거=2025-11-21 18:00:00)
- identifier=F63BC6C6-5E66-4999-8497-E4DC057DE6C9, trigger=UNTimeIntervalNotificationTrigger
- identifier=morning_notification, trigger=캘린더 트리거 (시간=08:00, 다음 트리거=2025-11-22 08:00:00)
- identifier=lunch_notification, trigger=캘린더 트리거 (시간=16:42, 다음 트리거=2025-11-21 16:42:00)
- identifier=dinner_notification, trigger=캘린더 트리거 (시간=18:00, 다음 트리거=2025-11-21 18:00:00)
```