### PR TITLE
Add Xcode Cloud script to generate Tuist workspace

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -euo pipefail
+
+# Install Tuist if it is not already available in the CI environment.
+if ! command -v tuist >/dev/null 2>&1; then
+  echo "Installing Tuist..."
+  curl -Ls https://install.tuist.io | bash
+  export PATH="$HOME/.tuist/bin:$PATH"
+fi
+
+cd MenuTaro
+
+echo "Fetching Tuist dependencies..."
+tuist fetch
+
+echo "Generating Xcode workspace..."
+tuist generate --no-open


### PR DESCRIPTION
## Summary
- add an Xcode Cloud post-clone script that installs Tuist, fetches dependencies, and generates the workspace

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921af51ca6883319411af0a9be817f8)